### PR TITLE
fixes bug where we did not assign getSpaces function in rac factory initialization

### DIFF
--- a/x-pack/plugins/rule_registry/server/authorization/rac_authorization.ts
+++ b/x-pack/plugins/rule_registry/server/authorization/rac_authorization.ts
@@ -75,6 +75,8 @@ export class RacAuthorization {
       features,
     });
 
+    console.error('ARE THERE ANY OWNERS???', owners);
+
     return new RacAuthorization({ request, authorization, owners, isAuthEnabled, auditLogger });
   }
 
@@ -90,6 +92,8 @@ export class RacAuthorization {
 
     // Does the owner the client sent up match with the KibanaFeatures structure
     const isAvailableOwner = this.featureOwners.has(owner);
+    console.error('THIS.FEATUREOWNERS', this.featureOwners);
+    console.error('IS AVAILABLE OWNER', isAvailableOwner);
 
     if (authorization != null && this.shouldCheckAuthorization()) {
       const requiredPrivileges = [authorization.actions.rac.get(owner, operation)];

--- a/x-pack/plugins/rule_registry/server/authorization/utils.ts
+++ b/x-pack/plugins/rule_registry/server/authorization/utils.ts
@@ -24,8 +24,9 @@ export const getEnabledKibanaSpaceFeatures = async ({
   features: FeaturesPluginStart;
 }): Promise<Set<string>> => {
   try {
+    console.error('GETSPACE', getSpace);
     const disabledUserSpaceFeatures = new Set((await getSpace(request))?.disabledFeatures ?? []);
-
+    console.error('DISABLED USER SPACE FEATURES', disabledUserSpaceFeatures);
     // Filter through all user Kibana features to find corresponding enabled
     // RAC feature owners like 'security-solution' or 'observability'
     const owners = await new Set(
@@ -34,11 +35,14 @@ export const getEnabledKibanaSpaceFeatures = async ({
         // get all the rac 'owners' that aren't disabled
         .filter(({ id }) => !disabledUserSpaceFeatures.has(id))
         .flatMap((feature) => {
+          console.error('FEATURE.RAC', feature.rac);
           return feature.rac ?? [];
         })
     );
+    console.error('INTERNAL OWNERS', owners);
     return owners;
   } catch (error) {
+    console.error('GETENABLEDKIBANASPACEFEAUTRES THREW AN ERROR');
     return new Set<string>();
   }
 };

--- a/x-pack/plugins/rule_registry/server/rac_client/rac_client.ts
+++ b/x-pack/plugins/rule_registry/server/rac_client/rac_client.ts
@@ -113,10 +113,7 @@ export class RacClient {
   }
 
   public async get<Params>({ id }: { id: string }): Promise<unknown> {
-    console.error('\n\n\n\n\nHELLO WORLD!!!!\n\n\n\n\n');
     // TODO: type alert for the get method
-    const thing = await this.esClient.ping();
-    console.error('PING RESULT', JSON.stringify(thing, null, 2));
     const result = await this.esClient.search({
       index: '.siem*',
       body: { query: { match_all: {} } },

--- a/x-pack/plugins/rule_registry/server/rac_client/rac_client_factory.ts
+++ b/x-pack/plugins/rule_registry/server/rac_client/rac_client_factory.ts
@@ -56,6 +56,7 @@ export class RacClientFactory {
     this.securityPluginSetup = options.securityPluginSetup;
     this.securityPluginStart = options.securityPluginStart;
     this.esClient = options.esClient;
+    this.getSpace = options.getSpace;
   }
 
   public async create(request: KibanaRequest): Promise<RacClient> {


### PR DESCRIPTION
…nitialization

## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the [cloud](https://github.com/elastic/cloud) and added to the [docker list](https://github.com/elastic/kibana/blob/c29adfef29e921cc447d2a5ed06ac2047ceab552/src/dev/build/tasks/os_packages/docker_generator/resources/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
