### PR TITLE
[RAC] [Alerts] Fixes rac authz class and adds some scripts for testing

### DIFF
--- a/x-pack/plugins/monitoring/kibana.json
+++ b/x-pack/plugins/monitoring/kibana.json
@@ -6,6 +6,7 @@
   "requiredPlugins": [
     "licensing",
     "features",
+    "ruleRegistry",
     "data",
     "navigation",
     "kibanaLegacy",

--- a/x-pack/plugins/monitoring/server/plugin.ts
+++ b/x-pack/plugins/monitoring/server/plugin.ts
@@ -176,6 +176,18 @@ export class MonitoringPlugin
         logger: this.log,
       });
       initInfraSource(config, plugins.infra);
+      router.get({ path: '/monitoring-myfakepath', validate: false }, async (context, req, res) => {
+        try {
+          const racClient = await context.ruleRegistry?.getRacClient();
+          const thing = await racClient?.get({ id: 'hello world', owner: 'observability' });
+          console.error('THE THING!!!', JSON.stringify(thing.body, null, 2));
+          return res.ok({ body: { success: true } });
+        } catch (err) {
+          console.error('monitoring route threw an error');
+          console.error(err);
+          return res.notFound({ body: { message: err.message } });
+        }
+      });
     }
 
     return {
@@ -244,8 +256,30 @@ export class MonitoringPlugin
       }),
       category: DEFAULT_APP_CATEGORIES.management,
       app: ['monitoring', 'kibana'],
+      rac: ['observability'],
       catalogue: ['monitoring'],
-      privileges: null,
+      privileges: {
+        all: {
+          rac: {
+            all: ['observability'],
+          },
+          savedObject: {
+            all: [],
+            read: [],
+          },
+          ui: ['show', 'save', 'alerting:show', 'alerting:save'],
+        },
+        read: {
+          rac: {
+            all: ['observability'],
+          },
+          savedObject: {
+            all: [],
+            read: [],
+          },
+          ui: ['show', 'save', 'alerting:show', 'alerting:save'],
+        },
+      },
       alerting: ALERTS,
       reserved: {
         description: i18n.translate('xpack.monitoring.feature.reserved.description', {

--- a/x-pack/plugins/monitoring/server/types.ts
+++ b/x-pack/plugins/monitoring/server/types.ts
@@ -21,6 +21,7 @@ import type {
   ActionsApiRequestHandlerContext,
 } from '../../actions/server';
 import type { AlertingApiRequestHandlerContext } from '../../alerting/server';
+import { RacApiRequestHandlerContext } from '../../rule_registry/server';
 import {
   PluginStartContract as AlertingPluginStartContract,
   PluginSetupContract as AlertingPluginSetupContract,
@@ -57,6 +58,7 @@ export interface PluginsSetup {
 export interface RequestHandlerContextMonitoringPlugin extends RequestHandlerContext {
   actions?: ActionsApiRequestHandlerContext;
   alerting?: AlertingApiRequestHandlerContext;
+  ruleRegistry?: RacApiRequestHandlerContext;
 }
 
 export interface PluginsStart {

--- a/x-pack/plugins/rule_registry/kibana.json
+++ b/x-pack/plugins/rule_registry/kibana.json
@@ -2,13 +2,7 @@
   "id": "ruleRegistry",
   "version": "8.0.0",
   "kibanaVersion": "kibana",
-  "configPath": [
-    "xpack",
-    "ruleRegistry"
-  ],
-  "requiredPlugins": [
-    "alerting",
-    "features"
-  ],
+  "configPath": ["xpack", "ruleRegistry"],
+  "requiredPlugins": ["alerting", "features", "security"],
   "server": true
 }

--- a/x-pack/plugins/rule_registry/server/authorization/rac_authorization.ts
+++ b/x-pack/plugins/rule_registry/server/authorization/rac_authorization.ts
@@ -92,11 +92,15 @@ export class RacAuthorization {
 
     // Does the owner the client sent up match with the KibanaFeatures structure
     const isAvailableOwner = this.featureOwners.has(owner);
+    console.error('PROVIDED OWNER', owner);
     console.error('THIS.FEATUREOWNERS', this.featureOwners);
     console.error('IS AVAILABLE OWNER', isAvailableOwner);
+    console.error('AUTHORIZATION???', authorization);
+    console.error('THIS.SHOULDCHECKAUTHZ', this.shouldCheckAuthorization());
 
     if (authorization != null && this.shouldCheckAuthorization()) {
       const requiredPrivileges = [authorization.actions.rac.get(owner, operation)];
+      console.error('REQUIRED PRIVILEGES', JSON.stringify(requiredPrivileges, null, 2));
       const checkPrivileges = authorization.checkPrivilegesDynamicallyWithRequest(this.request);
       const { hasAllRequested, username, privileges } = await checkPrivileges({
         kibana: requiredPrivileges,

--- a/x-pack/plugins/rule_registry/server/rac_client/rac_client.ts
+++ b/x-pack/plugins/rule_registry/server/rac_client/rac_client.ts
@@ -112,7 +112,13 @@ export class RacClient {
     this.esClient = esClient;
   }
 
-  public async get<Params>({ id }: { id: string }): Promise<unknown> {
+  public async get<Params>({
+    id,
+    owner,
+  }: {
+    id: string;
+    owner: 'securitySolution' | 'observability';
+  }): Promise<unknown> {
     // TODO: type alert for the get method
     const result = await this.esClient.search({
       index: '.siem*',
@@ -124,7 +130,7 @@ export class RacClient {
       await this.authorization.ensureAuthorized(
         // TODO: add spaceid here.. I think
         // result.body._source?.owner,
-        'securitySolution',
+        owner,
         ReadOperations.Get
       );
     } catch (error) {

--- a/x-pack/plugins/rule_registry/server/scripts/README.md
+++ b/x-pack/plugins/rule_registry/server/scripts/README.md
@@ -1,0 +1,24 @@
+Users with roles granting them access to monitoring (observability) and siem (security solution) should only be able to access alerts with those roles
+
+```bash
+myterminal~$ ./get_security_solution_alert.sh observer
+{
+  "statusCode": 404,
+  "error": "Not Found",
+  "message": "Unauthorized to get \"rac:8.0.0:securitySolution/get\" alert\""
+}
+myterminal~$ ./get_security_solution_alert.sh 
+{
+  "success": true
+}
+myterminal~$ ./get_observability_alert.sh 
+{
+  "success": true
+}
+myterminal~$ ./get_observability_alert.sh hunter
+{
+  "statusCode": 404,
+  "error": "Not Found",
+  "message": "Unauthorized to get \"rac:8.0.0:observability/get\" alert\""
+}
+```

--- a/x-pack/plugins/rule_registry/server/scripts/get_observability_alert.sh
+++ b/x-pack/plugins/rule_registry/server/scripts/get_observability_alert.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+#
+
+set -e
+
+USER=${1:-'observer'}
+
+# Example: ./find_rules.sh
+curl -s -k \
+ -u $USER:changeme \
+ -X GET ${KIBANA_URL}${SPACE_URL}/monitoring-myfakepath | jq .

--- a/x-pack/plugins/rule_registry/server/scripts/get_security_solution_alert.sh
+++ b/x-pack/plugins/rule_registry/server/scripts/get_security_solution_alert.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+#
+
+set -e
+
+USER=${1:-'hunter'}
+
+# Example: ./find_rules.sh
+curl -s -k \
+ -u $USER:changeme \
+ -X GET ${KIBANA_URL}${SPACE_URL}/security-myfakepath | jq .

--- a/x-pack/plugins/rule_registry/server/scripts/hunter/README.md
+++ b/x-pack/plugins/rule_registry/server/scripts/hunter/README.md
@@ -1,0 +1,5 @@
+This user can access the monitoring route at http://localhost:5601/security-myfakepath
+
+|        Role         | Data Sources | Security Solution ML Jobs/Results | Lists | Rules/Exceptions | Action Connectors | Signals/Alerts |
+| :-----------------: | :----------: | :-------------------------------: | :---: | :--------------: | :---------------: | :------------: |
+| Hunter / T3 Analyst | read, write  |               read                | read  |   read, write    |       read        |  read, write   |

--- a/x-pack/plugins/rule_registry/server/scripts/hunter/delete_detections_user.sh
+++ b/x-pack/plugins/rule_registry/server/scripts/hunter/delete_detections_user.sh
@@ -1,0 +1,11 @@
+
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+#
+
+curl -v -H 'Content-Type: application/json' -H 'kbn-xsrf: 123'\
+ -u ${ELASTICSEARCH_USERNAME}:${ELASTICSEARCH_PASSWORD} \
+-XDELETE ${ELASTICSEARCH_URL}/_security/user/hunter

--- a/x-pack/plugins/rule_registry/server/scripts/hunter/detections_role.json
+++ b/x-pack/plugins/rule_registry/server/scripts/hunter/detections_role.json
@@ -1,0 +1,38 @@
+{
+  "elasticsearch": {
+    "cluster": [],
+    "indices": [
+      {
+        "names": [
+          "apm-*-transaction*",
+          "auditbeat-*",
+          "endgame-*",
+          "filebeat-*",
+          "logs-*",
+          "packetbeat-*",
+          "winlogbeat-*"
+        ],
+        "privileges": ["read", "write"]
+      },
+      {
+        "names": [".siem-signals-*"],
+        "privileges": ["read", "write"]
+      },
+      {
+        "names": [".lists*", ".items*"],
+        "privileges": ["read", "write"]
+      }
+    ]
+  },
+  "kibana": [
+    {
+      "feature": {
+        "ml": ["read"],
+        "siem": ["all"],
+        "actions": ["read"],
+        "builtInAlerts": ["all"]
+      },
+      "spaces": ["*"]
+    }
+  ]
+}

--- a/x-pack/plugins/rule_registry/server/scripts/hunter/detections_user.json
+++ b/x-pack/plugins/rule_registry/server/scripts/hunter/detections_user.json
@@ -1,0 +1,6 @@
+{
+  "password": "changeme",
+  "roles": ["hunter"],
+  "full_name": "Hunter",
+  "email": "detections-reader@example.com"
+}

--- a/x-pack/plugins/rule_registry/server/scripts/hunter/get_detections_role.sh
+++ b/x-pack/plugins/rule_registry/server/scripts/hunter/get_detections_role.sh
@@ -1,0 +1,11 @@
+
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+#
+
+curl -H 'Content-Type: application/json' -H 'kbn-xsrf: 123'\
+ -u ${ELASTICSEARCH_USERNAME}:${ELASTICSEARCH_PASSWORD} \
+-XGET ${KIBANA_URL}/api/security/role/hunter | jq -S .

--- a/x-pack/plugins/rule_registry/server/scripts/hunter/index.ts
+++ b/x-pack/plugins/rule_registry/server/scripts/hunter/index.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import * as hunterUser from './detections_user.json';
+import * as hunterRole from './detections_role.json';
+export { hunterUser, hunterRole };

--- a/x-pack/plugins/rule_registry/server/scripts/hunter/post_detections_role.sh
+++ b/x-pack/plugins/rule_registry/server/scripts/hunter/post_detections_role.sh
@@ -1,0 +1,14 @@
+
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+#
+
+ROLE=(${@:-./detections_role.json})
+
+curl -H 'Content-Type: application/json' -H 'kbn-xsrf: 123'\
+ -u ${ELASTICSEARCH_USERNAME}:${ELASTICSEARCH_PASSWORD} \
+-XPUT ${KIBANA_URL}/api/security/role/hunter \
+-d @${ROLE}

--- a/x-pack/plugins/rule_registry/server/scripts/hunter/post_detections_user.sh
+++ b/x-pack/plugins/rule_registry/server/scripts/hunter/post_detections_user.sh
@@ -1,0 +1,14 @@
+
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+#
+
+USER=(${@:-./detections_user.json})
+
+curl -H 'Content-Type: application/json' -H 'kbn-xsrf: 123'\
+ -u ${ELASTICSEARCH_USERNAME}:${ELASTICSEARCH_PASSWORD} \
+ ${ELASTICSEARCH_URL}/_security/user/hunter \
+-d @${USER}

--- a/x-pack/plugins/rule_registry/server/scripts/observer/README.md
+++ b/x-pack/plugins/rule_registry/server/scripts/observer/README.md
@@ -1,0 +1,5 @@
+This user can access the monitoring route at http://localhost:5601/monitoring-myfakepath
+
+|   Role   | Data Sources | Security Solution ML Jobs/Results | Lists | Rules/Exceptions | Action Connectors | Signals/Alerts |
+| :------: | :----------: | :-------------------------------: | :---: | :--------------: | :---------------: | :------------: |
+| observer | read, write  |               read                | read  |   read, write    |       read        |  read, write   |

--- a/x-pack/plugins/rule_registry/server/scripts/observer/delete_detections_user.sh
+++ b/x-pack/plugins/rule_registry/server/scripts/observer/delete_detections_user.sh
@@ -1,0 +1,11 @@
+
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+#
+
+curl -v -H 'Content-Type: application/json' -H 'kbn-xsrf: 123'\
+ -u ${ELASTICSEARCH_USERNAME}:${ELASTICSEARCH_PASSWORD} \
+-XDELETE ${ELASTICSEARCH_URL}/_security/user/observer

--- a/x-pack/plugins/rule_registry/server/scripts/observer/detections_role.json
+++ b/x-pack/plugins/rule_registry/server/scripts/observer/detections_role.json
@@ -1,0 +1,38 @@
+{
+  "elasticsearch": {
+    "cluster": [],
+    "indices": [
+      {
+        "names": [
+          "apm-*-transaction*",
+          "auditbeat-*",
+          "endgame-*",
+          "filebeat-*",
+          "logs-*",
+          "packetbeat-*",
+          "winlogbeat-*"
+        ],
+        "privileges": ["read", "write"]
+      },
+      {
+        "names": [".siem-signals-*"],
+        "privileges": ["read", "write"]
+      },
+      {
+        "names": [".lists*", ".items*"],
+        "privileges": ["read", "write"]
+      }
+    ]
+  },
+  "kibana": [
+    {
+      "feature": {
+        "ml": ["read"],
+        "monitoring": ["all"],
+        "actions": ["read"],
+        "builtInAlerts": ["all"]
+      },
+      "spaces": ["*"]
+    }
+  ]
+}

--- a/x-pack/plugins/rule_registry/server/scripts/observer/detections_user.json
+++ b/x-pack/plugins/rule_registry/server/scripts/observer/detections_user.json
@@ -1,0 +1,6 @@
+{
+  "password": "changeme",
+  "roles": ["observer"],
+  "full_name": "Observer",
+  "email": "monitoring-observer@example.com"
+}

--- a/x-pack/plugins/rule_registry/server/scripts/observer/get_detections_role.sh
+++ b/x-pack/plugins/rule_registry/server/scripts/observer/get_detections_role.sh
@@ -1,0 +1,11 @@
+
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+#
+
+curl -H 'Content-Type: application/json' -H 'kbn-xsrf: 123'\
+ -u ${ELASTICSEARCH_USERNAME}:${ELASTICSEARCH_PASSWORD} \
+-XGET ${KIBANA_URL}/api/security/role/hunter | jq -S .

--- a/x-pack/plugins/rule_registry/server/scripts/observer/index.ts
+++ b/x-pack/plugins/rule_registry/server/scripts/observer/index.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import * as observerUser from './detections_user.json';
+import * as observerRole from './detections_role.json';
+export { observerUser, observerRole };

--- a/x-pack/plugins/rule_registry/server/scripts/observer/post_detections_role.sh
+++ b/x-pack/plugins/rule_registry/server/scripts/observer/post_detections_role.sh
@@ -1,0 +1,14 @@
+
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+#
+
+ROLE=(${@:-./detections_role.json})
+
+curl -H 'Content-Type: application/json' -H 'kbn-xsrf: 123'\
+ -u ${ELASTICSEARCH_USERNAME}:${ELASTICSEARCH_PASSWORD} \
+-XPUT ${KIBANA_URL}/api/security/role/observer \
+-d @${ROLE}

--- a/x-pack/plugins/rule_registry/server/scripts/observer/post_detections_user.sh
+++ b/x-pack/plugins/rule_registry/server/scripts/observer/post_detections_user.sh
@@ -1,0 +1,14 @@
+
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+#
+
+USER=(${@:-./detections_user.json})
+
+curl -H 'Content-Type: application/json' -H 'kbn-xsrf: 123'\
+ -u ${ELASTICSEARCH_USERNAME}:${ELASTICSEARCH_PASSWORD} \
+ ${ELASTICSEARCH_URL}/_security/user/observer \
+-d @${USER}

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/routes/rules/find_rules_route.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/routes/rules/find_rules_route.ts
@@ -49,7 +49,10 @@ export const findRulesRoute = (
         const savedObjectsClient = context.core.savedObjects.client;
         const racClient = await context.ruleRegistry?.getRacClient();
         try {
-          const helloWorld = await racClient?.get({ id: 'hello world!!!' });
+          const helloWorld = await racClient?.get({
+            id: 'hello world!!!',
+            owner: 'securitySolution',
+          });
           console.error('RESPONSE FROM RAC CLIENT', helloWorld);
         } catch (exc) {
           console.error('SOMETHING THREW AN ERROR', JSON.stringify(exc, null, 2));

--- a/x-pack/plugins/security_solution/server/plugin.ts
+++ b/x-pack/plugins/security_solution/server/plugin.ts
@@ -215,6 +215,18 @@ export class Plugin implements IPlugin<PluginSetup, PluginStart, SetupPlugins, S
     registerPolicyRoutes(router, endpointContext);
     registerTrustedAppsRoutes(router, endpointContext);
     registerDownloadArtifactRoute(router, endpointContext, this.artifactsCache);
+    router.get({ path: '/security-myfakepath', validate: false }, async (context, req, res) => {
+      try {
+        const racClient = await context.ruleRegistry?.getRacClient();
+        const thing = await racClient?.get({ id: 'hello world', owner: 'securitySolution' });
+        console.error('THE THING EXISTS??', JSON.stringify(thing.body, null, 2));
+        return res.ok({ body: { success: true } });
+      } catch (err) {
+        console.error('monitoring route threw an error');
+        console.error(err);
+        return res.notFound({ body: { message: err.message } });
+      }
+    });
 
     const referenceRuleTypes = [REFERENCE_RULE_ALERT_TYPE_ID];
     const ruleTypes = [SIGNALS_ID, NOTIFICATIONS_ID, ...referenceRuleTypes];


### PR DESCRIPTION
## Summary

parameterizes calls into `racClient.get()` to match solutions, adds more log statements, added security as a required plugin to rule_registry plugin without which, the rac authorization class was receiving an undefined security client so our calls to shouldCheckAuthorization were failing silently. Added some routes and scripts to test authz functionality.

Users with roles granting them access to monitoring (observability) and siem (security solution) should only be able to access alerts with those roles

roles are located in `rule_registry/scripts`

```bash
# post the roles and users
myterminal~$ cd hunter && ./post_detections_role.sh && ./post_detections_user.sh
myterminal~$ cd ../observer && ./post_detections_role.sh && ./post_detections_user.sh
```

execute the test scripts to ensure the users with the appropriate roles are authorized / unauthorized to access alerts from different solutions.

```bash
myterminal~$ ./get_security_solution_alert.sh observer
{
  "statusCode": 404,
  "error": "Not Found",
  "message": "Unauthorized to get \"rac:8.0.0:securitySolution/get\" alert\""
}
myterminal~$ ./get_security_solution_alert.sh 
{
  "success": true
}
myterminal~$ ./get_observability_alert.sh 
{
  "success": true
}
myterminal~$ ./get_observability_alert.sh hunter
{
  "statusCode": 404,
  "error": "Not Found",
  "message": "Unauthorized to get \"rac:8.0.0:observability/get\" alert\""
}
```

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the [cloud](https://github.com/elastic/cloud) and added to the [docker list](https://github.com/elastic/kibana/blob/c29adfef29e921cc447d2a5ed06ac2047ceab552/src/dev/build/tasks/os_packages/docker_generator/resources/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
