### PR TITLE
adds an 'owner' field to the siem-signals mapping, working authz get for security solution, need to work through rule registry changes

### DIFF
--- a/x-pack/plugins/rule_registry/server/index.ts
+++ b/x-pack/plugins/rule_registry/server/index.ts
@@ -9,7 +9,7 @@ import { schema, TypeOf } from '@kbn/config-schema';
 import { PluginInitializerContext } from 'src/core/server';
 import { RuleRegistryPlugin } from './plugin';
 
-export { RacPluginSetupContract } from './plugin';
+export { RuleRegistryPluginSetupContract } from './plugin';
 export { createLifecycleRuleTypeFactory } from './rule_registry/rule_type_helpers/create_lifecycle_rule_type_factory';
 export { FieldMapOf } from './types';
 export { ScopedRuleRegistryClient } from './rule_registry/create_scoped_rule_registry_client/types';

--- a/x-pack/plugins/rule_registry/server/rac_client/rac_client.ts
+++ b/x-pack/plugins/rule_registry/server/rac_client/rac_client.ts
@@ -15,6 +15,8 @@ import {
   GrantAPIKeyResult as SecurityPluginGrantAPIKeyResult,
   InvalidateAPIKeyResult as SecurityPluginInvalidateAPIKeyResult,
 } from '../../../security/server';
+import { SERVER_APP_ID } from '../../../security_solution/server';
+
 import {
   RacAuthorization,
   WriteOperations,
@@ -59,6 +61,11 @@ export interface FindOptions extends IndexType {
   };
   fields?: string[];
   filter?: string;
+}
+
+export interface createAlertParams {
+  esClient: ElasticsearchClient;
+  owner: 'observability' | 'securitySolution';
 }
 
 interface IndexType {
@@ -117,14 +124,8 @@ export class RacClient {
     owner,
   }: {
     id: string;
-    owner: 'securitySolution' | 'observability';
+    owner: typeof SERVER_APP_ID | 'observability';
   }): Promise<unknown> {
-    // TODO: type alert for the get method
-    const result = await this.esClient.search({
-      index: '.siem*',
-      body: { query: { match_all: {} } },
-    });
-    console.error(`************\nRESULT ${JSON.stringify(result, null, 2)}\n************`);
     // .get<RawAlert>('alert', id);
     try {
       await this.authorization.ensureAuthorized(
@@ -133,7 +134,37 @@ export class RacClient {
         owner,
         ReadOperations.Get
       );
+      // TODO: type alert for the get method
+
+      try {
+        // const result = await this.esClient.get({
+        //   index: '.siem-signals-devin-hurley-default',
+        //   id: 'ecf1d03a9f3456bb28bf3af5ef9fd2ef441641f3b495d92112e5e76d8feae62e',
+        // });
+        const result = await this.esClient.search({
+          index: '.siem-signals*',
+          body: {
+            query: {
+              term: {
+                'signal.owner': {
+                  value: owner,
+                },
+              },
+            },
+          },
+        });
+        console.error(`************\nRESULT ${JSON.stringify(result, null, 2)}\n************`);
+        return result;
+      } catch (exc) {
+        console.error('THREW ERROR WHEN TRYING GET', JSON.stringify(exc, null, 2));
+      }
+
+      // const result = await this.esClient.search({
+      //   index: '.siem*',
+      //   body: { query: { match_all: {} } },
+      // });
     } catch (error) {
+      console.error('HERES THE ERROR', error);
       // this.auditLogger?.log(
       //   alertAuditEvent({
       //     action: AlertAuditAction.GET,
@@ -152,7 +183,7 @@ export class RacClient {
     // TODO: strip out owner field maybe?
     // this.getAlertFromRaw<Params>(result.id, result.attributes, result.references);
 
-    return result;
+    // return result;
 
     // return Promise.resolve({ id: 'hello world!!!' });
     // const result = await this.unsecuredSavedObjectsClient.get<RawAlert>('alert', id);
@@ -337,4 +368,6 @@ export class RacClient {
     // ]);
     // return updateResult;
   }
+
+  static async create({ esClient, owner, data }: createAlertParams) {}
 }

--- a/x-pack/plugins/rule_registry/server/rule_registry/rule_type_helpers/create_lifecycle_rule_type_factory.ts
+++ b/x-pack/plugins/rule_registry/server/rule_registry/rule_type_helpers/create_lifecycle_rule_type_factory.ts
@@ -168,7 +168,8 @@ export function createLifecycleRuleTypeFactory(): CreateLifecycleRuleType<BaseRu
               ...alertData,
               '@timestamp': timestamp,
               'event.kind': 'state',
-              'kibana.rac.alert.id': alertId,
+              // 'owner': ''
+              // 'kibana.rac.alert.id': alertId,
             };
 
             const isNew = !state.trackedAlerts[alertId];

--- a/x-pack/plugins/security_solution/server/index.ts
+++ b/x-pack/plugins/security_solution/server/index.ts
@@ -8,7 +8,7 @@
 import { PluginInitializerContext, PluginConfigDescriptor } from '../../../../src/core/server';
 import { Plugin, PluginSetup, PluginStart } from './plugin';
 import { configSchema, ConfigType } from './config';
-import { SIGNALS_INDEX_KEY } from '../common/constants';
+import { SIGNALS_INDEX_KEY, SERVER_APP_ID } from '../common/constants';
 import { AppClient } from './types';
 
 export const plugin = (context: PluginInitializerContext) => {
@@ -46,7 +46,7 @@ export const config: PluginConfigDescriptor<ConfigType> = {
 };
 
 export { ConfigType, Plugin, PluginSetup, PluginStart };
-export { AppClient };
+export { AppClient, SERVER_APP_ID };
 
 // Exports to be shared with plugins such as x-pack/lists plugin
 export { deleteTemplate } from './lib/detection_engine/index/delete_template';

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/routes/index/signals_mapping.json
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/routes/index/signals_mapping.json
@@ -77,6 +77,9 @@
               }
             }
           },
+          "owner": {
+            "type": "keyword"
+          },
           "rule": {
             "properties": {
               "id": {

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/signals/build_bulk_body.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/signals/build_bulk_body.ts
@@ -18,17 +18,19 @@ import {
 import { buildRuleWithoutOverrides, buildRuleWithOverrides } from './build_rule';
 import { additionalSignalFields, buildSignal } from './build_signal';
 import { buildEventTypeSignal } from './build_event_type_signal';
+import { SERVER_APP_ID } from '../../../../common/constants';
 import { EqlSequence } from '../../../../common/detection_engine/types';
 import { generateSignalId, wrapBuildingBlocks, wrapSignal } from './utils';
 
 // format search_after result for signals index.
 export const buildBulkBody = (
   ruleSO: SavedObject<AlertAttributes>,
-  doc: SignalSourceHit
+  doc: SignalSourceHit,
+  owner: typeof SERVER_APP_ID
 ): SignalHit => {
   const rule = buildRuleWithOverrides(ruleSO, doc._source!);
   const signal: Signal = {
-    ...buildSignal([doc], rule),
+    ...buildSignal([doc], rule, owner),
     ...additionalSignalFields(doc),
   };
   const event = buildEventTypeSignal(doc);

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/signals/build_signal.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/signals/build_signal.ts
@@ -6,6 +6,7 @@
  */
 
 import { SearchTypes } from '../../../../common/detection_engine/types';
+import { SERVER_APP_ID } from '../../../../common/constants';
 import { RulesSchema } from '../../../../common/detection_engine/schemas/response/rules_schema';
 import { SIGNALS_TEMPLATE_VERSION } from '../routes/index/get_signals_template';
 import { isEventTypeSignal } from './build_event_type_signal';
@@ -76,7 +77,11 @@ export const removeClashes = (doc: BaseSignalHit): BaseSignalHit => {
  * @param docs The parent signals/events of the new signal to be built.
  * @param rule The rule that is generating the new signal.
  */
-export const buildSignal = (docs: BaseSignalHit[], rule: RulesSchema): Signal => {
+export const buildSignal = (
+  docs: BaseSignalHit[],
+  rule: RulesSchema,
+  owner: typeof SERVER_APP_ID
+): Signal => {
   const _meta = {
     version: SIGNALS_TEMPLATE_VERSION,
   };
@@ -92,6 +97,7 @@ export const buildSignal = (docs: BaseSignalHit[], rule: RulesSchema): Signal =>
     parents,
     ancestors,
     status: 'open',
+    owner,
     rule,
     depth,
   };

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/signals/single_bulk_create.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/signals/single_bulk_create.ts
@@ -12,6 +12,8 @@ import {
   AlertInstanceState,
   AlertServices,
 } from '../../../../../alerting/server';
+
+import { SERVER_APP_ID } from '../../../../common/constants';
 import { AlertAttributes, SignalHit, SignalSearchResponse, WrappedSignalHit } from './types';
 import { RefreshTypes } from '../types';
 import { generateId, makeFloatString, errorAggregator } from './utils';
@@ -121,7 +123,7 @@ export const singleBulkCreate = async ({
         ),
       },
     },
-    buildBulkBody(ruleSO, doc),
+    buildBulkBody(ruleSO, doc, SERVER_APP_ID),
   ]);
   const start = performance.now();
   const { body: response } = await services.scopedClusterClient.asCurrentUser.bulk({
@@ -140,7 +142,7 @@ export const singleBulkCreate = async ({
     .map((doc, index) => ({
       _id: response.items[index].create?._id ?? '',
       _index: response.items[index].create?._index ?? '',
-      ...buildBulkBody(ruleSO, doc),
+      ...buildBulkBody(ruleSO, doc, SERVER_APP_ID),
     }))
     .filter((_, index) => get(response.items[index], 'create.status') === 201);
   const createdItemsCount = createdItems.length;

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/signals/types.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/signals/types.ts
@@ -211,6 +211,7 @@ export interface Signal {
   };
   original_time?: string;
   original_event?: SearchTypes;
+  owner?: string;
   status: Status;
   threshold_result?: ThresholdResult;
   original_signal?: SearchTypes;

--- a/x-pack/plugins/security_solution/server/plugin.ts
+++ b/x-pack/plugins/security_solution/server/plugin.ts
@@ -217,9 +217,9 @@ export class Plugin implements IPlugin<PluginSetup, PluginStart, SetupPlugins, S
     router.get({ path: '/security-myfakepath', validate: false }, async (context, req, res) => {
       try {
         const racClient = await context.ruleRegistry?.getRacClient();
-        const thing = await racClient?.get({ id: 'hello world', owner: 'securitySolution' });
-        console.error('THE THING EXISTS??', JSON.stringify(thing.body, null, 2));
-        return res.ok({ body: { success: true } });
+        const thing = await racClient?.get({ id: 'hello world', owner: SERVER_APP_ID });
+        console.error('hits?', JSON.stringify(thing.body.hits.hits, null, 2));
+        return res.ok({ body: { success: true, thing: thing.body.hits.hits } });
       } catch (err) {
         console.error('monitoring route threw an error');
         console.error(err);
@@ -236,12 +236,12 @@ export class Plugin implements IPlugin<PluginSetup, PluginStart, SetupPlugins, S
       order: 1100,
       app: [...securitySubPlugins, 'kibana'],
       category: DEFAULT_APP_CATEGORIES.security,
-      rac: ['securitySolution'],
+      rac: [SERVER_APP_ID],
       privileges: {
         all: {
           app: [...securitySubPlugins, 'kibana'],
           rac: {
-            all: ['securitySolution'],
+            all: [SERVER_APP_ID],
           },
           savedObject: {
             all: [
@@ -275,11 +275,11 @@ export class Plugin implements IPlugin<PluginSetup, PluginStart, SetupPlugins, S
         insightsAndAlerting: ['triggersActions'],
       },
       alerting: ruleTypes,
-      rac: ['securitySolution'],
+      rac: [SERVER_APP_ID],
       privileges: {
         all: {
           rac: {
-            all: ['securitySolution'],
+            all: [SERVER_APP_ID],
           },
           app: [...securitySubPlugins, 'kibana'],
           catalogue: ['securitySolution'],
@@ -320,7 +320,7 @@ export class Plugin implements IPlugin<PluginSetup, PluginStart, SetupPlugins, S
             read: ruleTypes,
           },
           rac: {
-            all: ['securitySolution'],
+            all: [SERVER_APP_ID],
           },
           management: {
             insightsAndAlerting: ['triggersActions'],


### PR DESCRIPTION
adds an 'owner' field to the siem-signals mapping, working authz get for security solution, need to work through rule registry changes

## Summary

Pull down [this branch](https://github.com/elastic/elasticsearch/pull/72181) and run ES locally using the following steps..

Running ES locally
1. Edit `gradle/run.gradle` and add setting `'xpack.security.authc.api_key.enabled', 'true'` after line 24
2. ./gradlew run # this runs with a trial license
3. Execute below curl script to post `kibana_elastic` user
```bash
curl -u elastic:password -X POST "http://127.0.01:9200/_security/user/kibana_elastic?pretty" -H 'Content-Type: application/json' -d '{"password":"changeme","roles":["superuser"],"full_name":"kibana","email":"jacknich@example.com"}'
```
4. Set `kibana.dev.yml` to use `kibana_elastic` as the user
```yaml
elasticsearch:
  username: 'kibana_elastic'
  password: 'changeme'
  hosts: 'http://127.0.0.1:9200'
```
Start up kibana


You should now be able to create a rule which generates alerts and then "find" those alerts (using the kibana system user) using the scripts located in `x-pack/plugins/rule_registry/server/scripts/get_security_solution_alert.sh`
