### PR TITLE
Adds update functionality and update route with scripts.

### DIFF
--- a/x-pack/plugins/apm/server/feature.ts
+++ b/x-pack/plugins/apm/server/feature.ts
@@ -23,6 +23,7 @@ export const APM_FEATURE = {
   category: DEFAULT_APP_CATEGORIES.observability,
   app: ['apm', 'ux', 'kibana'],
   catalogue: ['apm'],
+  rac: [APM_SERVER_FEATURE_ID],
   management: {
     insightsAndAlerting: ['triggersActions'],
   },
@@ -33,6 +34,9 @@ export const APM_FEATURE = {
       app: ['apm', 'ux', 'kibana'],
       api: ['apm', 'apm_write'],
       catalogue: ['apm'],
+      rac: {
+        all: [APM_SERVER_FEATURE_ID],
+      },
       savedObject: {
         all: [],
         read: [],
@@ -49,6 +53,9 @@ export const APM_FEATURE = {
       app: ['apm', 'ux', 'kibana'],
       api: ['apm'],
       catalogue: ['apm'],
+      rac: {
+        all: [APM_SERVER_FEATURE_ID],
+      },
       savedObject: {
         all: [],
         read: [],

--- a/x-pack/plugins/rule_registry/server/authorization/audit_logger.ts
+++ b/x-pack/plugins/rule_registry/server/authorization/audit_logger.ts
@@ -49,9 +49,9 @@ export class RacAuthorizationAuditLogger {
       message,
       event: {
         action: 'rac_authorization_failure',
-        category: EventCategory.DATABASE,
+        category: 'database', // EventCategory.DATABASE,
         type,
-        outcome: EventOutcome.FAILURE,
+        outcome: 'failure', // EventOutcome.FAILURE,
       },
       user: {
         name: username,
@@ -105,9 +105,9 @@ export class RacAuthorizationAuditLogger {
       message,
       event: {
         action: 'rac_authorization_success',
-        category: EventCategory.DATABASE,
+        category: 'database',
         type,
-        outcome: EventOutcome.SUCCESS,
+        outcome: 'success',
       },
       user: {
         name: username,

--- a/x-pack/plugins/rule_registry/server/authorization/rac_authorization.ts
+++ b/x-pack/plugins/rule_registry/server/authorization/rac_authorization.ts
@@ -7,7 +7,7 @@
 import Boom from '@hapi/boom';
 
 import { KibanaRequest } from 'src/core/server';
-import { EventType, SecurityPluginStart } from '../../../security/server';
+import { SecurityPluginStart } from '../../../security/server';
 import { PluginStartContract as FeaturesPluginStart } from '../../../features/server';
 import { Space } from '../../../spaces/server';
 import { KueryNode } from '../../../../../src/plugins/data/server';
@@ -118,7 +118,7 @@ export class RacAuthorization {
             owner,
             username,
             operation,
-            type: EventType.ACCESS,
+            type: 'rac authz', // EventType.ACCESS,
           })
         );
       }
@@ -127,7 +127,7 @@ export class RacAuthorization {
           owner,
           username,
           operation,
-          type: EventType.ACCESS,
+          type: 'rac authz', // EventType.ACCESS,
         });
       } else {
         const authorizedPrivileges = privileges.kibana.reduce<string[]>((acc, privilege) => {
@@ -145,7 +145,7 @@ export class RacAuthorization {
             owner: unauthorizedPrivilages.join(','),
             username,
             operation,
-            type: EventType.ACCESS,
+            type: 'rac authz', // EventType.ACCESS,
           })
         );
       }
@@ -155,7 +155,7 @@ export class RacAuthorization {
           owner,
           username: '',
           operation,
-          type: EventType.ACCESS,
+          type: 'rac authz', // EventType.ACCESS,
         })
       );
     }

--- a/x-pack/plugins/rule_registry/server/plugin.ts
+++ b/x-pack/plugins/rule_registry/server/plugin.ts
@@ -104,7 +104,12 @@ export class RuleRegistryPlugin implements Plugin<RuleRegistryPluginSetupContrac
     router.post(
       {
         path: '/update-alert',
-        validate: false,
+        validate: {
+          body: schema.object({
+            status: schema.string(),
+            id: schema.string(),
+          }),
+        },
       },
       async (context, req, res) => {
         try {
@@ -114,13 +119,14 @@ export class RuleRegistryPlugin implements Plugin<RuleRegistryPluginSetupContrac
           console.error('STATUS', status);
           console.error('ID', id);
           const thing = await racClient?.update({
-            id: 'Dh1IYnkB0N8iW9VY-cL0',
+            id,
             owner: 'apm',
-            data: { status: 'closed' },
+            data: { status },
           });
           return res.ok({ body: { success: true, alerts: thing } });
         } catch (exc) {
           console.error('OOPS', exc);
+          return res.unauthorized();
         }
       }
     );

--- a/x-pack/plugins/rule_registry/server/plugin.ts
+++ b/x-pack/plugins/rule_registry/server/plugin.ts
@@ -107,7 +107,7 @@ export class RuleRegistryPlugin implements Plugin<RuleRegistryPluginSetupContrac
         validate: {
           body: schema.object({
             status: schema.string(),
-            id: schema.string(),
+            ids: schema.arrayOf(schema.string()),
           }),
         },
       },
@@ -115,11 +115,11 @@ export class RuleRegistryPlugin implements Plugin<RuleRegistryPluginSetupContrac
         try {
           const racClient = await context.ruleRegistry?.getRacClient();
           console.error(req);
-          const { status, id } = req.body;
+          const { status, ids } = req.body;
           console.error('STATUS', status);
-          console.error('ID', id);
+          console.error('ID', ids);
           const thing = await racClient?.update({
-            id,
+            ids,
             owner: 'apm',
             data: { status },
           });

--- a/x-pack/plugins/rule_registry/server/plugin.ts
+++ b/x-pack/plugins/rule_registry/server/plugin.ts
@@ -15,6 +15,7 @@ import {
   KibanaRequest,
   IContextProvider,
 } from 'src/core/server';
+import { schema } from '@kbn/config-schema';
 import { PublicMethodsOf } from '@kbn/utility-types';
 import { SecurityPluginSetup, SecurityPluginStart } from '../../security/server';
 import {
@@ -99,6 +100,30 @@ export class RuleRegistryPlugin implements Plugin<RuleRegistryPluginSetupContrac
       racClient?.get({ id: 'hello world' });
       return res.ok();
     });
+
+    router.post(
+      {
+        path: '/update-alert',
+        validate: false,
+      },
+      async (context, req, res) => {
+        try {
+          const racClient = await context.ruleRegistry?.getRacClient();
+          console.error(req);
+          const { status, id } = req.body;
+          console.error('STATUS', status);
+          console.error('ID', id);
+          const thing = await racClient?.update({
+            id: 'Dh1IYnkB0N8iW9VY-cL0',
+            owner: 'apm',
+            data: { status: 'closed' },
+          });
+          return res.ok({ body: { success: true, alerts: thing } });
+        } catch (exc) {
+          console.error('OOPS', exc);
+        }
+      }
+    );
 
     return rootRegistry;
   }

--- a/x-pack/plugins/rule_registry/server/rac_client/rac_client.ts
+++ b/x-pack/plugins/rule_registry/server/rac_client/rac_client.ts
@@ -84,7 +84,7 @@ export interface FindResult<Params extends AlertTypeParams> {
 }
 
 export interface UpdateOptions<Params extends AlertTypeParams> {
-  id: string;
+  ids: string[];
   owner: string;
   data: {
     status: string;
@@ -322,7 +322,7 @@ export class RacClient {
   }
 
   public async update<Params extends AlertTypeParams = never>({
-    id,
+    ids,
     owner,
     data,
   }: UpdateOptions<Params>): Promise<PartialAlert<Params>> {
@@ -336,30 +336,26 @@ export class RacClient {
       // TODO: type alert for the get method
 
       try {
-        // const result = await this.esClient.get({
-        //   index: '.siem-signals-devin-hurley-default',
-        //   id: 'ecf1d03a9f3456bb28bf3af5ef9fd2ef441641f3b495d92112e5e76d8feae62e',
-        // });
-        const result = await this.esClient.update({
-          index: '.kibana-devin-hurley-alerts-observability-apm-8.0.0',
-          id,
-          body: {
-            doc: {
-              'kibana.rac.alert.status': data.status,
+        const body = ids.flatMap((id) => [
+          {
+            update: {
+              _id: id,
             },
           },
+          {
+            doc: { 'kibana.rac.alert.status': data.status },
+          },
+        ]);
+
+        const result = await this.esClient.bulk({
+          index: '.kibana-devin-hurley-alerts-observability-apm-8.0.0',
+          body,
         });
-        // console.error(`************\nRESULT ${JSON.stringify(result, null, 2)}\n************`);
         return result;
       } catch (exc) {
         console.error(exc);
         console.error('THREW ERROR WHEN TRYING UPDATE', JSON.stringify(exc, null, 2));
       }
-
-      // const result = await this.esClient.search({
-      //   index: '.siem*',
-      //   body: { query: { match_all: {} } },
-      // });
     } catch (error) {
       console.error('HERES THE ERROR', error);
       // this.auditLogger?.log(

--- a/x-pack/plugins/rule_registry/server/scripts/observer/detections_role.json
+++ b/x-pack/plugins/rule_registry/server/scripts/observer/detections_role.json
@@ -29,6 +29,7 @@
       "feature": {
         "ml": ["read"],
         "monitoring": ["all"],
+        "apm": ["all"],
         "actions": ["read"],
         "builtInAlerts": ["all"]
       },

--- a/x-pack/plugins/rule_registry/server/scripts/update_observability_alert.sh
+++ b/x-pack/plugins/rule_registry/server/scripts/update_observability_alert.sh
@@ -1,0 +1,19 @@
+set -e
+
+ID=${1}
+STATUS=${2}
+
+echo "'"$ID"'"
+echo "'"$STATUS"'"
+
+cd ./hunter && sh ./post_detections_role.sh && sh ./post_detections_user.sh
+cd ../observer && sh ./post_detections_role.sh && sh ./post_detections_user.sh
+cd ..
+
+# Example: ./find_rules.sh
+curl -s -k \
+ -H 'Content-Type: application/json' \
+ -H 'kbn-xsrf: 123' \
+ -u observer:changeme \
+ -X POST ${KIBANA_URL}${SPACE_URL}/update-alert \
+ -d {"id":"Dh1IYnkB0N8iW9VY-cL0", "status":"closed"} | jq .

--- a/x-pack/plugins/rule_registry/server/scripts/update_observability_alert.sh
+++ b/x-pack/plugins/rule_registry/server/scripts/update_observability_alert.sh
@@ -1,19 +1,19 @@
 set -e
 
-ID=${1}
+IDS=${1}
 STATUS=${2}
 
-echo "'"$ID"'"
+echo $IDS
 echo "'"$STATUS"'"
 
 cd ./hunter && sh ./post_detections_role.sh && sh ./post_detections_user.sh
 cd ../observer && sh ./post_detections_role.sh && sh ./post_detections_user.sh
 cd ..
 
-# Example: ./update_observability_alert.sh <some alert id> <closed | open>
+# Example: ./update_observability_alert.sh [\"my-alert-id\",\"another-alert-id\"] <closed | open>
 curl -s -k \
  -H 'Content-Type: application/json' \
  -H 'kbn-xsrf: 123' \
  -u observer:changeme \
  -X POST ${KIBANA_URL}${SPACE_URL}/update-alert \
- -d '{"id":"'"$ID"'", "status":"'"$STATUS"'"}' | jq .
+ -d "{\"ids\": $IDS, \"status\":\"$STATUS\"}" | jq .

--- a/x-pack/plugins/rule_registry/server/scripts/update_observability_alert.sh
+++ b/x-pack/plugins/rule_registry/server/scripts/update_observability_alert.sh
@@ -10,10 +10,10 @@ cd ./hunter && sh ./post_detections_role.sh && sh ./post_detections_user.sh
 cd ../observer && sh ./post_detections_role.sh && sh ./post_detections_user.sh
 cd ..
 
-# Example: ./find_rules.sh
+# Example: ./update_observability_alert.sh <some alert id> <closed | open>
 curl -s -k \
  -H 'Content-Type: application/json' \
  -H 'kbn-xsrf: 123' \
  -u observer:changeme \
  -X POST ${KIBANA_URL}${SPACE_URL}/update-alert \
- -d {"id":"Dh1IYnkB0N8iW9VY-cL0", "status":"closed"} | jq .
+ -d '{"id":"'"$ID"'", "status":"'"$STATUS"'"}' | jq .


### PR DESCRIPTION
## Summary

### Run ES locally
1. Edit `buildSrc/src/main/groovy/elasticsearch.run.gradle` and add setting `'xpack.security.authc.api_key.enabled', 'true'` after line 24
2. `./gradlew run` # this runs with a trial license
3. Execute below curl script to post `kibana_elastic` user
```bash
curl -u elastic:password -X POST "http://127.0.01:9200/_security/user/kibana_elastic?pretty" -H 'Content-Type: application/json' -d '{"password":"changeme","roles":["superuser"],"full_name":"kibana","email":"jacknich@example.com"}'
```
4. Set `kibana.dev.yml` to use `kibana_elastic` as the user
```yaml
elasticsearch:
  username: 'kibana_elastic'
  password: 'changeme'
  hosts: 'http://127.0.0.1:9200'
```

### APM server
1. download latest apm server from https://github.com/elastic/apm-server/releases and unpack and setup and run `./apm-server -e`
2. Create a toy server using the apm setup
3. `yarn add elastic-apm-node && yarn add express`

```nodejs
const apm = require('elastic-apm-node').start({
serviceName: 'demoapp',
  // Set the custom APM Server URL (default: http://localhost:8200)
  serverUrl: 'http://localhost:8200',

  // Set the service environment
  environment: 'production'
});

const express = require('express');
const app = express();
app.get('/', (req, res) => {
  throw Error('HELLO WORLD!!'); // throw error for apm rule to pickup
});

app.listen(3000, () => console.log('server running on 3000'));
```

`node index.js` and server should pring `server running on 3000`

### Start kibana

Set `kibana.dev.yml` to use `kibana_elastic` as the user
```yaml
elasticsearch:
  username: 'kibana_elastic'
  password: 'changeme'
  hosts: 'http://127.0.0.1:9200'
```
Start up kibana

Go to APM and create an `Error count threshold rule` looking for one error.

Ping `http://localhost:3000` which will throw an error, send it to APM and the apm error count rule will generate an alert and send it to the `.kibana-alerts-observability-apm-8.0.0-000001`.


Test updating an alert by querying 

```
GET .kibana-<your-name>-alerts*/_search
{
  "query": {
    "match_all": {}
  }
}
```

grab an ID and send it through the update script like so

```
term$ cd x-pack/plugins/rule_registry/server/scripts
term$ ./update_observability_alert.sh [\"<some-id>\"] <closed | open>
```

todo:
* need to figure out how to build index alias name
* ~~figure out why request body is not being passed through to route~~ fixed: b52324f19c9f23ebf0e2a7fc4255a17ebde6f346
